### PR TITLE
Playlist Notification Tasks

### DIFF
--- a/includes/admin/events/taxonomies.php
+++ b/includes/admin/events/taxonomies.php
@@ -142,10 +142,11 @@ add_action( 'edited_enquiry-source', 'mdjm_save_enquiry_source', 10, 2 );
  * @return	str
  */
 function mdjm_add_playlist_category_fields( $tag )	{
+
 	?>
     <div class="form-field term-group">
         <label for="playlist_default_cat"><?php _e( 'Set as default Category?', 'mobile-dj-manager' ); ?></label>
-        <input type="checkbox" name="playlist_default_cat" id="playlist_default_cat" value="<?php echo $tag->term_id; ?>" />
+        <input type="checkbox" name="playlist_default_cat" id="playlist_default_cat" value="1" />
     </div>
     <?php
 	

--- a/includes/admin/tasks/task-functions.php
+++ b/includes/admin/tasks/task-functions.php
@@ -165,6 +165,8 @@ function mdjm_filter_task_run_times( $run_times, $id )	{
 		$unset = array( 'after_approval', 'before_event', 'after_event' );
 	} elseif( 'request-deposit' == $id || 'balance-reminder' == $id )	{
 		$unset = array( 'event_created', 'after_event' );
+	} elseif( 'playlist-employee-notify' == $id )	{
+		$unset = array( 'event_created', 'after_event', 'after_approval' );
 	}
 
 	if ( isset( $unset ) )	{

--- a/includes/admin/tasks/tasks-page.php
+++ b/includes/admin/tasks/tasks-page.php
@@ -141,7 +141,7 @@ function mdjm_render_single_task_view( $id ) {
 
 											<p>
 												<span class="label"><?php _e( 'Next Due:', 'mobile-dj-manager' ); ?>&nbsp;</span>
-                                                <?php if ( ! empty( $task['nextrun'] ) && 'Never' != $task['nextrun'] ) : ?>
+                                                <?php if ( ! empty( $task['nextrun'] ) && 'N/A' != $task['nextrun'] ) : ?>
                                                      <?php echo date_i18n( get_option( 'time_format' ) . ' ' . get_option( 'date_format' ), $task['nextrun'] ); ?>
                                                 <?php else : ?>
                                                     <?php echo __( 'N/A', 'mobile-dj-manager' ); ?>

--- a/includes/admin/tasks/tasks-page.php
+++ b/includes/admin/tasks/tasks-page.php
@@ -73,6 +73,8 @@ function mdjm_render_single_task_view( $id ) {
 	$url            = remove_query_arg( array( 'mdjm-message', 'render' ) );
 	$task           = mdjm_get_task( $id );
 	$run_when       = explode( ' ', $task['options']['age'] );
+    $run_times      = mdjm_get_task_run_times( $id );
+    $hide_runtimes  = 'playlist-notification' == $id ? ' mdjm-hidden' : '';
 	$return_url     = add_query_arg( array(
 		'post_type' => 'mdjm-event',
 		'page'      => 'mdjm-tasks'
@@ -130,12 +132,20 @@ function mdjm_render_single_task_view( $id ) {
 										<div class="mdjm-admin-box-inside mdjm-task-stats">
                                         	<p>
 												<span class="label"><?php _e( 'Last Ran:', 'mobile-dj-manager' ); ?>&nbsp;</span>
-                                                <?php echo date_i18n( get_option( 'time_format' ) . ' ' . get_option( 'date_format' ), $task['lastran'] ); ?>
+                                                <?php if ( ! empty( $task['lastran'] ) && 'Never' != $task['lastran'] ) : ?>
+                                                    <?php echo date_i18n( get_option( 'time_format' ) . ' ' . get_option( 'date_format' ), $task['lastran'] ); ?>
+                                                <?php else : ?>
+                                                    <?php echo __( 'Never', 'mobile-dj-manager' ); ?>
+                                                <?php endif; ?>
                                             </p>
 
 											<p>
 												<span class="label"><?php _e( 'Next Due:', 'mobile-dj-manager' ); ?>&nbsp;</span>
-                                                <?php echo date_i18n( get_option( 'time_format' ) . ' ' . get_option( 'date_format' ), $task['nextrun'] ); ?>
+                                                <?php if ( ! empty( $task['nextrun'] ) && 'Never' != $task['nextrun'] ) : ?>
+                                                     <?php echo date_i18n( get_option( 'time_format' ) . ' ' . get_option( 'date_format' ), $task['nextrun'] ); ?>
+                                                <?php else : ?>
+                                                    <?php echo __( 'N/A', 'mobile-dj-manager' ); ?>
+                                                <?php endif; ?>
                                             </p>
 
 											<p>
@@ -241,44 +251,44 @@ function mdjm_render_single_task_view( $id ) {
 
 									<?php do_action( 'mdjm_task_view_details_after_description', $id ); ?>
 
-									<div class="column-container task-info">
+                                    <div class="column-container task-info<?php echo $hide_runtimes; ?>">
                                         <p><strong><?php _e( 'Run this task:', 'mobile-dj-manager' ); ?></strong>
                                         <br />
                                         <?php
-											$run_intervals = array();
-											for( $i = 1; $i <= 12; $i++ )	{
-												$run_intervals[ $i ] = $i;
-											}
+                                            $run_intervals = array();
+                                            for( $i = 1; $i <= 12; $i++ )	{
+                                                $run_intervals[ $i ] = $i;
+                                            }
 
-										?>
+                                        ?>
                                         <?php echo MDJM()->html->select( array(
                                             'name'     => 'task_run_time',
-											'id'       => 'task-run-time',
-											'selected' => $run_when[0],
-											'options'  => $run_intervals
+                                            'id'       => 'task-run-time',
+                                            'selected' => $run_when[0],
+                                            'options'  => $run_intervals
                                         ) ); ?>
                                         &nbsp;&nbsp;
                                         <?php echo MDJM()->html->select( array(
                                             'name'     => 'task_run_period',
-											'id'       => 'task-run-period',
-											'selected' => $run_when[1],
-											'options'  => array(
-												'HOUR'  => __( 'Hour(s)', 'mobile-dj-manager' ),
-												'DAY'   => __( 'Day(s)', 'mobile-dj-manager' ),
-												'WEEK'  => __( 'Week(s)', 'mobile-dj-manager' ),
-												'MONTH' => __( 'Month(s)', 'mobile-dj-manager' ),
-												'YEAR'  => __( 'Year(s)', 'mobile-dj-manager' )
-											)
+                                            'id'       => 'task-run-period',
+                                            'selected' => $run_when[1],
+                                            'options'  => array(
+                                                'HOUR'  => __( 'Hour(s)', 'mobile-dj-manager' ),
+                                                'DAY'   => __( 'Day(s)', 'mobile-dj-manager' ),
+                                                'WEEK'  => __( 'Week(s)', 'mobile-dj-manager' ),
+                                                'MONTH' => __( 'Month(s)', 'mobile-dj-manager' ),
+                                                'YEAR'  => __( 'Year(s)', 'mobile-dj-manager' )
+                                            )
                                         ) ); ?>
                                         &nbsp;&nbsp;
                                         <?php echo MDJM()->html->select( array(
                                             'name'     => 'task_run_event_status',
-											'id'       => 'task-run-event-status',
-											'selected' => $task['options']['run_when'],
-											'options'  => mdjm_get_task_run_times( $id )
+                                            'id'       => 'task-run-event-status',
+                                            'selected' => $task['options']['run_when'],
+                                            'options'  => $run_times
                                         ) ); ?>
                                         </p>
-									</div>
+                                    </div>
 
 									<?php do_action( 'mdjm_task_view_details', $id ); ?>
 

--- a/includes/class-mdjm-cron.php
+++ b/includes/class-mdjm-cron.php
@@ -226,6 +226,22 @@ class MDJM_Cron	{
 				'default'             => true,
 				'last_result'         => false
             ),
+			'playlist-employee-notify' => array(
+				'slug'              => 'playlist-employee-notify',
+				'name'              => __( 'Employee Playlist Notification', 'mobile-dj-manager' ),
+				'active'            => false,
+				'desc'              => sprintf( __( 'Sends notifications to an employee if an %s playlist has entries.', 'mobile-dj-manager' ), mdjm_get_label_singular() ),
+				'frequency'         => 'Daily',
+				'nextrun'           => 'N/A',
+				'lastran'           => 'Never',
+				'options'           => array(
+					'run_when'        => 'before_event',
+					'age'             => '3 DAYS'
+				),
+				'totalruns'           => '0',
+				'default'             => true,
+				'last_result'         => false
+			),
 			'upload-playlists'      => array(
 				'slug'              => 'upload-playlists',
 				'name'              => __( 'Upload Playlists', 'mobile-dj-manager' ),

--- a/includes/class-mdjm-cron.php
+++ b/includes/class-mdjm-cron.php
@@ -238,7 +238,7 @@ class MDJM_Cron	{
 					'run_when'        => 'before_event',
 					'age'             => '3 DAY',
 					'email_template'  => '0',
-					'email_subject'   => sprintf( __( '%s playlist notification', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
+					'email_subject'   => sprintf( __( '%s playlist notification', 'mobile-dj-manager' ), mdjm_get_label_singular() ),
 					'email_from'      => 'admin'
 				),
 				'totalruns'           => '0',

--- a/includes/class-mdjm-cron.php
+++ b/includes/class-mdjm-cron.php
@@ -206,7 +206,26 @@ class MDJM_Cron	{
 				'totalruns'          => '0',
 				'default'            => true,
 				'last_result'        => false
-			),		
+			),
+            'playlist-notification' => array(
+                'slug'              => 'playlist-notification',
+				'name'              => __( 'Client Playlist Notifications', 'mobile-dj-manager' ),
+				'active'            => false,
+				'desc'              => __( 'Sends notifications to clients if a guest has added an entry to the playlist.', 'mobile-dj-manager' ),
+				'frequency'         => 'Daily',
+				'nextrun'           => 'N/A',
+				'lastran'           => 'Never',
+				'options'           => array(
+                    'run_when'        => 'after_event',
+					'age'             => '1 HOUR',
+                    'email_template'  => '0',
+					'email_subject'   => sprintf( __( 'Your %s playlist has been updated', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
+					'email_from'      => 'admin'
+				),
+				'totalruns'           => '0',
+				'default'             => true,
+				'last_result'         => false
+            ),
 			'upload-playlists'      => array(
 				'slug'              => 'upload-playlists',
 				'name'              => __( 'Upload Playlists', 'mobile-dj-manager' ),

--- a/includes/class-mdjm-cron.php
+++ b/includes/class-mdjm-cron.php
@@ -230,13 +230,16 @@ class MDJM_Cron	{
 				'slug'              => 'playlist-employee-notify',
 				'name'              => __( 'Employee Playlist Notification', 'mobile-dj-manager' ),
 				'active'            => false,
-				'desc'              => sprintf( __( 'Sends notifications to an employee if an %s playlist has entries.', 'mobile-dj-manager' ), mdjm_get_label_singular() ),
+				'desc'              => sprintf( __( 'Sends notifications to an employee if an %s playlist has entries.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
 				'frequency'         => 'Daily',
 				'nextrun'           => 'N/A',
 				'lastran'           => 'Never',
 				'options'           => array(
 					'run_when'        => 'before_event',
-					'age'             => '3 DAYS'
+					'age'             => '3 DAY',
+					'email_template'  => '0',
+					'email_subject'   => sprintf( __( '%s playlist notification', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
+					'email_from'      => 'admin'
 				),
 				'totalruns'           => '0',
 				'default'             => true,

--- a/includes/class-mdjm-task-runner.php
+++ b/includes/class-mdjm-task-runner.php
@@ -730,6 +730,11 @@ class MDJM_Task_Runner {
 					'source'         => sprintf( __( '%s Scheduled Task', 'mobile-dj-manager' ), $this->name )
 				);
 
+				if ( 'employee' == $this->options['email_from'] && ! empty( $event->employee_id ) )	{
+					$email_args['from_email'] = $employee->user_email;
+					$email_args['from_name']  = $employee->display_name;
+				}
+
 				if ( mdjm_send_email_content( $email_args ) )	{
 					MDJM()->debug->log_it( $this->name . ' sent to ' . $employee->display_name );
 

--- a/includes/class-mdjm-task-runner.php
+++ b/includes/class-mdjm-task-runner.php
@@ -873,15 +873,15 @@ class MDJM_Task_Runner {
                 break;
 
 			case 'playlist-employee-notify':
+				$start = date( 'Y-m-d' );
+				$end   = date( 'Y-m-d', strtotime( "+" . $this->options['age'] ) );
 				$query = array(
 					'post_status'  => 'mdjm-approved',
 					'meta_query'   => array(
-						'relation' => 'AND',
-						$date_query,
 						array(
 							'key'     => '_mdjm_event_date',
-							'compare' => '<=',
-							'value'   => date( 'Y-m-d' ),
+							'compare' => 'BETWEEN',
+							'value'   => array( $start, $end ),
 							'type'    => 'date'
 						)
 					)

--- a/includes/playlist/playlist-actions.php
+++ b/includes/playlist/playlist-actions.php
@@ -286,3 +286,18 @@ function mdjm_print_playlist_action( $data )	{
 	die();
 } // mdjm_add_playlist_entry
 add_action( 'mdjm_add_playlist_entry', 'mdjm_add_playlist_entry_action' );
+
+/**
+ * Sets the flag to notify clients when a guest entry is added
+ *
+ * @since   1.5
+ * @param   int     $entry_id   The playlist entry ID
+ * @param   int     $event_id   The event ID
+ * @return  void
+ */
+function mdjm_event_playlist_set_guest_notification_action( $entry_id, $event_id )  {
+    if ( mdjm_is_task_active( 'playlist-notification' ) ) {
+        update_post_meta( $event_id, '_mdjm_playlist_client_notify', '1', true );
+    }
+} // mdjm_event_playlist_set_guest_notification_action
+add_action( 'mdjm_insert_guest_playlist_entry', 'mdjm_event_playlist_set_guest_notification_action', 10, 2 );

--- a/includes/playlist/playlist-actions.php
+++ b/includes/playlist/playlist-actions.php
@@ -234,60 +234,6 @@ function mdjm_add_guest_playlist_entry_action( $data )	{
 add_action( 'mdjm_add_guest_playlist_entry', 'mdjm_add_guest_playlist_entry_action' );
 
 /**
- * Print the playlist.
- *
- * @since	1.3
- * @param	arr		$data	Form data from the $_POST super global.
- * @return	void
- */
-function mdjm_print_playlist_action( $data )	{
-	if( ! wp_verify_nonce( $data[ 'mdjm_nonce' ], 'print_playlist' ) )	{
-		$message = 'nonce_fail';
-	}
-	
-	elseif( ! isset( $data[ 'event_id' ] ) )	{
-		$message = 'playlist_data_missing';
-	}
-	
-	else	{
-		// Setup the playlist entry details
-		$posted = array();
-	
-		foreach ( $data as $key => $value ) {
-	
-			if( $key != 'mdjm_nonce' && $key != 'mdjm_action' && $key != 'mdjm_redirect' && $key != 'entry_addnew' ) {
-				if( is_string( $value ) || is_int( $value ) )	{
-					$posted[ $key ] = strip_tags( addslashes( $value ) );
-	
-				}
-				elseif( is_array( $value ) )	{
-					$posted[ $key ] = array_map( 'absint', $value );
-				}
-			}
-		}
-		
-		if( mdjm_store_playlist_entry( $posted ) )	{
-			$message = 'playlist_added';
-		}
-		else	{
-			$message = 'playlist_not_added';
-		}
-	}
-	
-	wp_redirect(
-		add_query_arg(
-			array(
-				'event_id'	 => $data['entry_event'],
-				'mdjm_message' => $message
-			),
-			mdjm_get_formatted_url( mdjm_get_option( 'playlist_page' ) )
-		)
-	);
-	die();
-} // mdjm_add_playlist_entry
-add_action( 'mdjm_add_playlist_entry', 'mdjm_add_playlist_entry_action' );
-
-/**
  * Sets the flag to notify clients when a guest entry is added
  *
  * @since   1.5

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -183,9 +183,7 @@ function mdjm_store_guest_playlist_entry( $details )	{
 	$event_id	= $details['entry_event'];
 
 	// Add the playlist entry
-	$meta = apply_filters( 'mdjm_insert_guest_playlist_entry', $meta );
-
-	do_action( 'mdjm_insert_guest_playlist_entry_before', $meta );
+	$meta = apply_filters( 'mdjm_insert_guest_playlist_entry_meta', $meta );
 
 	$title = sprintf( __( 'Event ID: %s %s %s', 'mobile-dj-manager' ),
 				mdjm_get_option( 'event_prefix', '' ) . $event_id,
@@ -211,7 +209,7 @@ function mdjm_store_guest_playlist_entry( $details )	{
 		update_post_meta( $entry_id, '_mdjm_playlist_entry_' . $key, $value );
 	}
 
-	do_action( 'mdjm_insert_guest_playlist_entry_after', $meta, $entry_id );
+	do_action( 'mdjm_insert_guest_playlist_entry', $entry_id, $event_id );
 
 	// Playlist entry added
 	return $entry_id;

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -308,11 +308,10 @@ function mdjm_get_playlist_by_category( $event_id, $args=array() )	{
  *
  * @since	1.3
  * @param	int		$event_id	The event ID.
- * @param	arr		$args		See codex get_terms
  * @return	arr		Array of all unique playlist categories.
  */
-function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
-	$terms		= mdjm_get_playlist_categories( $args );
+function mdjm_get_event_playlist_categories( $event_id )	{
+	$terms		= mdjm_get_playlist_categories();
 	$categories = array();
 
 	if ( ! $terms )	{
@@ -470,11 +469,13 @@ function mdjm_guest_playlist_url( $event_id )	{
  * Retrieve all playlist categories.
  *
  * @since	1.3
- * @param	arr			$args		See codex get_terms
  * @return	obj|bool	Array of categories, or false if none.
  */
-function mdjm_get_playlist_categories( $args=array() )	{
-	$terms = get_terms( 'playlist-category', $args );
+function mdjm_get_playlist_categories()	{
+	$terms = get_terms( array(
+		'taxonomy'   => 'playlist-category',
+		'hide_empty' => false
+	) );
 
 	if ( ! empty( $terms ) && ! is_wp_error( $terms ) )	{
 		return $terms;


### PR DESCRIPTION
Adds two (2) new automated tasks in relation to event playlists.

1) A daily task which emails clients when a guest adds an entry to their playlist

2) A task that runs x number of days before an event takes place and emails the primary employee if the playlist has entries.

Closes #178 