### PR TITLE
Playlist Entry Limits

### DIFF
--- a/assets/js/admin-scripts.js
+++ b/assets/js/admin-scripts.js
@@ -211,6 +211,7 @@ jQuery(document).ready(function ($) {
 			this.client();
 			this.employee();
 			this.equipment();
+			this.playlist();
 			this.time();
 			this.travel();
 			this.type();
@@ -537,7 +538,13 @@ jQuery(document).ready(function ($) {
 			});
 
 		},
-		
+
+		playlist : function()	{
+			$( document.body ).on( 'change', '#_mdjm_event_playlist', function() {
+				$('#mdjm-playlist-limit').slideToggle();
+			});
+		},
+
 		time : function()	{
 			// Set the DJ Setup Date
 			$( document.body ).on( 'change', '#display_event_date', function() {

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -638,7 +638,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 
     <?php echo MDJM()->html->number( array(
        			'name'  => '_mdjm_event_playlist_limit',
- 	              	'value' => $playlist_limit; ?></p>
+ 	              	'value' => $playlist_limit ) ); ?></p>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -609,6 +609,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	global $mdjm_event, $mdjm_event_update;
 
 	$enable_playlist = mdjm_get_option( 'enable_playlists', true );
+	$limit_class     = '';
 
 	if ( ! $mdjm_event_update || 'mdjm-unattended' == $mdjm_event->post_status ) {
         $playlist_limit = mdjm_playlist_global_limit();
@@ -616,6 +617,10 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
         $playlist_limit  = mdjm_get_event_playlist_limit( $mdjm_event->ID );
         $enable_playlist = $mdjm_event->playlist_is_enabled();
     }
+
+	if ( ! $enable_playlist )	{
+		$limit_class = ' class="mdjm-hidden"';
+	}
 
 	if ( ! $playlist_limit ) {
 		$playlist_limit = 0;
@@ -631,12 +636,13 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
         'current'  => $enable_playlist ? 'Y' : 0,
     ) ); ?> <?php _e( 'Enable Playlist?', 'mobile-dj-manager' ); ?></p>
 
-    <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
-
-    <?php echo MDJM()->html->number( array(
-        'name'  => '_mdjm_event_playlist_limit',
-        'value' => $playlist_limit
-    ) ); ?></p>
+    <div id="mdjm-playlist-limit" <?php echo $limit_class; ?>>
+        <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
+        <?php echo MDJM()->html->number( array(
+            'name'  => '_mdjm_event_playlist_limit',
+            'value' => $playlist_limit
+        ) ); ?></p>
+	</div>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -609,7 +609,16 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	global $mdjm_event, $mdjm_event_update;
 
 	$enable_playlist = mdjm_get_option( 'enable_playlists', true );
-	$playlist_limit  = $mdjm_event->get_meta( '_mdjm_event_playlist_limit' );
+
+	if ( ! $mdjm_event_update ) {
+    		$playlist_limit = mdjm_get_option( 'playlist_limit' );
+	} else {
+    		$playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID );
+		}
+
+	if ( ! $playlist_limit ) {
+		$playlist_limit = 0;
+	}
 
 	if ( $mdjm_event_update )	{
 		$enable_playlist = $mdjm_event->playlist_is_enabled();
@@ -628,9 +637,8 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
     <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
 
     <?php echo MDJM()->html->number( array(
-       		 	 'name'  => '_mdjm_event_playlist_limit',
-                	 'class' => '',
-                 	'value' => ! empty( $playlist_limit ) ? $playlist_limit : '' ) ); ?></p>
+       			'name'  => '_mdjm_event_playlist_limit',
+ 	              	'value' => ! empty( $playlist_limit ) ? $playlist_limit : '' ) ); ?></p>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -638,7 +638,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 
     <?php echo MDJM()->html->number( array(
        			'name'  => '_mdjm_event_playlist_limit',
- 	              	'value' => ! empty( $playlist_limit ) ? $playlist_limit : '' ) ); ?></p>
+ 	              	'value' => $playlist_limit; ?></p>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -609,6 +609,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	global $mdjm_event, $mdjm_event_update;
 
 	$enable_playlist = mdjm_get_option( 'enable_playlists', true );
+	$pl_limit = $mdjm_event->get_meta( '_mdjm_event_playlist_limit' );
 
 	if ( $mdjm_event_update )	{
 		$enable_playlist = $mdjm_event->playlist_is_enabled();
@@ -623,6 +624,14 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 			'value'    => 'Y',
 			'current'  => $enable_playlist ? 'Y' : 0,
 		) ); ?> <?php _e( 'Enable Playlist?', 'mobile-dj-manager' ); ?></p>
+
+    <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
+
+    <?php echo MDJM()->html->text( array(
+        	 'name'  => '_mdjm_event_playlist_limit',
+                 'class' => '',
+                 'value' => ! empty( $pl_limit ) ? $pl_limit : ''
+                ) ); ?></p>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -609,7 +609,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	global $mdjm_event, $mdjm_event_update;
 
 	$enable_playlist = mdjm_get_option( 'enable_playlists', true );
-	$pl_limit = $mdjm_event->get_meta( '_mdjm_event_playlist_limit' );
+	$playlist_limit  = $mdjm_event->get_meta( '_mdjm_event_playlist_limit' );
 
 	if ( $mdjm_event_update )	{
 		$enable_playlist = $mdjm_event->playlist_is_enabled();
@@ -627,11 +627,10 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 
     <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
 
-    <?php echo MDJM()->html->text( array(
-        	 'name'  => '_mdjm_event_playlist_limit',
-                 'class' => '',
-                 'value' => ! empty( $pl_limit ) ? $pl_limit : ''
-                ) ); ?></p>
+    <?php echo MDJM()->html->number( array(
+       		 	 'name'  => '_mdjm_event_playlist_limit',
+                	 'class' => '',
+                 	'value' => ! empty( $playlist_limit ) ? $playlist_limit : '' ) ); ?></p>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -611,7 +611,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	$enable_playlist = mdjm_get_option( 'enable_playlists', true );
 
 	if ( ! $mdjm_event_update || 'mdjm-unattended' == $mdjm_event->post_status ) {
-        $playlist_limit = mdjm_get_option( 'playlist_limit' );
+        $playlist_limit = mdjm_playlist_global_limit();
 	} else {
         $playlist_limit  = mdjm_get_event_playlist_limit( $mdjm_event->ID );
         $enable_playlist = $mdjm_event->playlist_is_enabled();

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -637,7 +637,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
     ) ); ?> <?php _e( 'Enable Playlist?', 'mobile-dj-manager' ); ?></p>
 
     <div id="mdjm-playlist-limit" <?php echo $limit_class; ?>>
-        <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
+        <p><?php _e ( 'Playlist Limit:', 'mobile-dj-manager' ); ?>
         <?php echo MDJM()->html->number( array(
             'name'  => '_mdjm_event_playlist_limit',
             'value' => $playlist_limit

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -610,18 +610,15 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 
 	$enable_playlist = mdjm_get_option( 'enable_playlists', true );
 
-	if ( ! $mdjm_event_update ) {
-    		$playlist_limit = mdjm_get_option( 'playlist_limit' );
+	if ( ! $mdjm_event_update || 'mdjm-unattended' == $mdjm_event->post_status ) {
+        $playlist_limit = mdjm_get_option( 'playlist_limit' );
 	} else {
-    		$playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID );
-		}
+        $playlist_limit  = mdjm_get_playlist_limit( $mdjm_event->ID );
+        $enable_playlist = $mdjm_event->playlist_is_enabled();
+    }
 
 	if ( ! $playlist_limit ) {
 		$playlist_limit = 0;
-	}
-
-	if ( $mdjm_event_update )	{
-		$enable_playlist = $mdjm_event->playlist_is_enabled();
 	}
 
 	?>
@@ -629,16 +626,17 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	<p><strong><?php printf( __( '%s Options', 'mobile-dj-manager' ), mdjm_get_label_singular() ); ?></strong></p>
 
     <p><?php echo MDJM()->html->checkbox( array(
-			'name'     => '_mdjm_event_playlist',
-			'value'    => 'Y',
-			'current'  => $enable_playlist ? 'Y' : 0,
-		) ); ?> <?php _e( 'Enable Playlist?', 'mobile-dj-manager' ); ?></p>
+        'name'     => '_mdjm_event_playlist',
+        'value'    => 'Y',
+        'current'  => $enable_playlist ? 'Y' : 0,
+    ) ); ?> <?php _e( 'Enable Playlist?', 'mobile-dj-manager' ); ?></p>
 
     <p><?php _e ( 'Playlist Limit', 'mobile-dj-manager' ); ?>
 
     <?php echo MDJM()->html->number( array(
-       			'name'  => '_mdjm_event_playlist_limit',
- 	              	'value' => $playlist_limit ) ); ?></p>
+        'name'  => '_mdjm_event_playlist_limit',
+        'value' => $playlist_limit
+    ) ); ?></p>
 
     <?php
 

--- a/includes/admin/events/metaboxes.php
+++ b/includes/admin/events/metaboxes.php
@@ -613,7 +613,7 @@ function mdjm_event_metabox_options_playlist_row( $event_id )	{
 	if ( ! $mdjm_event_update || 'mdjm-unattended' == $mdjm_event->post_status ) {
         $playlist_limit = mdjm_get_option( 'playlist_limit' );
 	} else {
-        $playlist_limit  = mdjm_get_playlist_limit( $mdjm_event->ID );
+        $playlist_limit  = mdjm_get_event_playlist_limit( $mdjm_event->ID );
         $enable_playlist = $mdjm_event->playlist_is_enabled();
     }
 

--- a/includes/admin/mdjm.php
+++ b/includes/admin/mdjm.php
@@ -99,6 +99,7 @@
 				define( 'MDJM_SHORTDATE_FORMAT', isset( $mdjm_settings['main']['short_date_format'] ) ? $mdjm_settings['main']['short_date_format'] : 'd/m/Y' );
 				define( 'MDJM_EVENT_PREFIX', isset( $mdjm_settings['events']['event_prefix'] ) ? $mdjm_settings['events']['event_prefix'] : '' );
 				define( 'MDJM_PLAYLIST_ENABLE', !empty( $mdjm_settings['playlist']['enable_playlists'] ) ? true : false );
+                                define( 'MDJM_PLAYLIST_LIMIT', isset( $mdjm_settings['playlist']['playlist_limit'] ) ? $mdjm_settings['playlist']['playlist_limit'] : '0' );
 				define( 'MDJM_PLAYLIST_CLOSE', isset( $mdjm_settings['playlist']['close'] ) ? $mdjm_settings['playlist']['close'] : '0' );
 				define( 'MDJM_PAYMENTS', ( !empty( $mdjm_settings['payments']['payment_gateway'] ) ? true : false ) );
 				define( 'MDJM_COMPANY', isset( $mdjm_settings['main']['company_name'] ) ? $mdjm_settings['main']['company_name'] : '' );

--- a/includes/admin/mdjm.php
+++ b/includes/admin/mdjm.php
@@ -99,7 +99,6 @@
 				define( 'MDJM_SHORTDATE_FORMAT', isset( $mdjm_settings['main']['short_date_format'] ) ? $mdjm_settings['main']['short_date_format'] : 'd/m/Y' );
 				define( 'MDJM_EVENT_PREFIX', isset( $mdjm_settings['events']['event_prefix'] ) ? $mdjm_settings['events']['event_prefix'] : '' );
 				define( 'MDJM_PLAYLIST_ENABLE', !empty( $mdjm_settings['playlist']['enable_playlists'] ) ? true : false );
-                                define( 'MDJM_PLAYLIST_LIMIT', isset( $mdjm_settings['playlist']['playlist_limit'] ) ? $mdjm_settings['playlist']['playlist_limit'] : '0' );
 				define( 'MDJM_PLAYLIST_CLOSE', isset( $mdjm_settings['playlist']['close'] ) ? $mdjm_settings['playlist']['close'] : '0' );
 				define( 'MDJM_PAYMENTS', ( !empty( $mdjm_settings['payments']['payment_gateway'] ) ? true : false ) );
 				define( 'MDJM_COMPANY', isset( $mdjm_settings['main']['company_name'] ) ? $mdjm_settings['main']['company_name'] : '' );

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -477,7 +477,17 @@ function mdjm_get_registered_settings()	{
 										'to help build an information library. The consolidated list of playlist songs will be freely shared. ' . 
 										'Only song, artist and the %s type information is transmitted.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
 						'type'        => 'checkbox'
+					),
+					'playlist_limit' => array(
+						'id'          => 'playlist_limit',
+						'name'        => __( 'Playlist Limit?', 'mobile-dj-manager' ),
+						'desc'        => sprintf( __( 'If this number is non-zero, event playlists will be limited to this number of entries ', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
+
+						'type'        => 'text',
+                                                'size'	      => 'small',
+                                                'std'         => '0'
 					)
+
 				),
 				// Packages & Addons
 				'packages' => array(

--- a/includes/admin/settings/register-settings.php
+++ b/includes/admin/settings/register-settings.php
@@ -458,6 +458,14 @@ function mdjm_get_registered_settings()	{
 						'type'        => 'checkbox',
 						'std'         => '1'
 					),
+					'playlist_limit' => array(
+						'id'          => 'playlist_limit',
+						'name'        => __( 'Playlist Limit?', 'mobile-dj-manager' ),
+						'desc'        => sprintf( __( 'Set the global limit for the number of entries a playlist can contain or enter 0 for no limit.  If this number is non-zero, %s playlists will be limited to this number of entries ', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
+						'type'        => 'number',
+                                                'size'	      => 'small',
+                                                'std'         => '0'
+					),
 					'close'           => array(
 						'id'          => 'close',
 						'name'        => __( 'Close the Playlist', 'mobile-dj-manager' ),
@@ -477,17 +485,7 @@ function mdjm_get_registered_settings()	{
 										'to help build an information library. The consolidated list of playlist songs will be freely shared. ' . 
 										'Only song, artist and the %s type information is transmitted.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
 						'type'        => 'checkbox'
-					),
-					'playlist_limit' => array(
-						'id'          => 'playlist_limit',
-						'name'        => __( 'Playlist Limit?', 'mobile-dj-manager' ),
-						'desc'        => sprintf( __( 'If this number is non-zero, event playlists will be limited to this number of entries ', 'mobile-dj-manager' ), mdjm_get_label_singular( true ) ),
-
-						'type'        => 'text',
-                                                'size'	      => 'small',
-                                                'std'         => '0'
 					)
-
 				),
 				// Packages & Addons
 				'packages' => array(

--- a/includes/events/class-mdjm-event.php
+++ b/includes/events/class-mdjm-event.php
@@ -1084,8 +1084,7 @@ class MDJM_Event {
 	 * @return number
 	 */
 	public function get_playlist_limit() {
-		$pl_limit = get_post_meta( $this->ID, '_mdjm_event_playlist_limit', true );
-		return $pl_limit;
+   		return mdjm_get_playlist_limit( $this->ID );
 	} // get_playlist_limit
 
 	/**

--- a/includes/events/class-mdjm-event.php
+++ b/includes/events/class-mdjm-event.php
@@ -241,7 +241,7 @@ class MDJM_Event {
 			'_mdjm_event_dj'                 => ! mdjm_get_option( 'employer' ) ? 1 : 0,
 			'_mdjm_event_playlist_access'    => mdjm_generate_playlist_guest_code(),
 			'_mdjm_event_playlist'           => mdjm_get_option( 'enable_playlists' ) ? 'Y' : 'N',
-			'_mdjm_event_playlist_limit'	 => mdjm_get_option( 'playlist_limit' ),
+			'_mdjm_event_playlist_limit'	 => mdjm_playlist_global_limit(),
 			'_mdjm_event_contract'           => mdjm_get_default_event_contract(),
 			'_mdjm_event_cost'               => 0,
 			'_mdjm_event_deposit'            => 0,

--- a/includes/events/class-mdjm-event.php
+++ b/includes/events/class-mdjm-event.php
@@ -1079,13 +1079,14 @@ class MDJM_Event {
 
 		return apply_filters( 'mdjm_playlist_status', $return, $this->ID );
 	} // is_playlist_enabled
+
 	/** Get the playlist limit
 	 * @return number
 	 */
-public function get_playlist_limit() {
-	$pl_limit = get_post_meta( $this->ID, '_mdjm_event_playlist_limit', true );
-	return $pl_limit;
-}
+	public function get_playlist_limit() {
+		$pl_limit = get_post_meta( $this->ID, '_mdjm_event_playlist_limit', true );
+		return $pl_limit;
+	} // get_playlist_limit
 
 	/**
 	 * Determine if the playlist is open.

--- a/includes/events/class-mdjm-event.php
+++ b/includes/events/class-mdjm-event.php
@@ -241,6 +241,7 @@ class MDJM_Event {
 			'_mdjm_event_dj'                 => ! mdjm_get_option( 'employer' ) ? 1 : 0,
 			'_mdjm_event_playlist_access'    => mdjm_generate_playlist_guest_code(),
 			'_mdjm_event_playlist'           => mdjm_get_option( 'enable_playlists' ) ? 'Y' : 'N',
+			'_mdjm_event_playlist_limit'	 => mdjm_get_option( 'playlist_limit' ),
 			'_mdjm_event_contract'           => mdjm_get_default_event_contract(),
 			'_mdjm_event_cost'               => 0,
 			'_mdjm_event_deposit'            => 0,
@@ -1078,6 +1079,13 @@ class MDJM_Event {
 
 		return apply_filters( 'mdjm_playlist_status', $return, $this->ID );
 	} // is_playlist_enabled
+	/** Get the playlist limit
+	 * @return number
+	 */
+public function get_playlist_limit() {
+	$pl_limit = get_post_meta( $this->ID, '_mdjm_event_playlist_limit', true );
+	return $pl_limit;
+}
 
 	/**
 	 * Determine if the playlist is open.

--- a/includes/events/class-mdjm-event.php
+++ b/includes/events/class-mdjm-event.php
@@ -1084,7 +1084,7 @@ class MDJM_Event {
 	 * @return number
 	 */
 	public function get_playlist_limit() {
-   		return mdjm_get_playlist_limit( $this->ID );
+   		return mdjm_get_event_playlist_limit( $this->ID );
 	} // get_playlist_limit
 
 	/**

--- a/includes/events/event-functions.php
+++ b/includes/events/event-functions.php
@@ -351,7 +351,8 @@ function mdjm_get_event_data( $event )	{
 		'playlist'            => array(
 			'playlist_enabled'    => $mdjm_event->playlist_is_enabled(),
 			'playlist_guest_code' => $mdjm_event->get_playlist_code(),
-			'playlist_status'     => $mdjm_event->playlist_is_open()
+			'playlist_status'     => $mdjm_event->playlist_is_open(),
+                        'playlist_limit'      => $mdjm_event->get_playlist_limit(),
 		),
 		'setup_date'          => $mdjm_event->get_setup_date(),
 		'setup_time'          => $mdjm_event->get_setup_time(),
@@ -1805,6 +1806,7 @@ function mdjm_event_get_meta_label( $key )	{
 		'_mdjm_event_package'           => __( 'Package', 'mobile-dj-manager' ),
 		'_mdjm_event_playlist'          => __( 'Playlist Enabled', 'mobile-dj-manager' ),
 		'_mdjm_event_playlist_access'   => __( 'Playlist Guest Access Code', 'mobile-dj-manager' ),
+		'_mdjm_event_playlist_limit'	=> __( 'Playlist Limit', 'mobile-dj-manager' ),
 		'_mdjm_event_start'             => __( 'Start Time', 'mobile-dj-manager' ),
 		'_mdjm_event_travel_data'       => __( 'Travel Data', 'mobile-dj-manager' ),
 		'_mdjm_event_venue_address1'    => __( 'Venue Address Line 1', 'mobile-dj-manager' ),

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -347,7 +347,6 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
 /** Get the playlist limit for this event
  *
  */
-
 function mdjm_get_playlist_limit ( $event_id )  {
      $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
      return $playlist_limit;

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -344,6 +344,15 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
 	return $categories;
 } // mdjm_get_event_playlist_categories
 
+/** Get the playlist  limit count
+ *
+ */
+
+function mdjm_get_playlist_limit ( $event_id )  {
+     $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
+     return $playlist_limit;
+}
+
 /**
  * Determine if this event has playlists enabled.
  *

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -344,11 +344,15 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
 	return $categories;
 } // mdjm_get_event_playlist_categories
 
-/** Get the playlist limit for this event
+/** Get the playlist limit for an event
  *
+ * @since   1.5
+ * @param   int     $event_id   Event ID
+ * @return  int|false
  */
 function mdjm_get_playlist_limit ( $event_id ) {
      $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
+
      return apply_filters( 'mdjm_event_playlist_limit', $playlist_limit, $event_id );
 } // mdjm_get_playlist_limit
 

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -349,7 +349,7 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
  */
 function mdjm_get_playlist_limit ( $event_id ) {
      $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
-     return $playlist_limit;
+     return apply_filters( 'mdjm_event_playlist_limit', $playlist_limit, $event_id );
 } // mdjm_get_playlist_limit
 
 /**

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -12,6 +12,16 @@ if ( ! defined( 'ABSPATH' ) )
 	exit;
 
 /**
+ * Retrieve the global playlist limit.
+ *
+ * @since	1.5
+ * @return	int  	The number of entries playlists are limited to by default.
+ */
+function mdjm_playlist_global_limit()	{
+	return (int) mdjm_get_option( 'playlist_limit' );
+} // mdjm_playlist_global_limit
+
+/**
  * Get Playlist Entry
  *
  * Retrieves a complete entry by entry ID.

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -347,7 +347,7 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
 /** Get the playlist limit for this event
  *
  */
-function mdjm_get_playlist_limit ( $event_id )  {
+function mdjm_get_playlist_limit ( $event_id ) {
      $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
      return $playlist_limit;
 } // mdjm_get_playlist_limit

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -350,11 +350,11 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
  * @param   int     $event_id   Event ID
  * @return  int|false
  */
-function mdjm_get_playlist_limit ( $event_id ) {
+function mdjm_get_event_playlist_limit ( $event_id ) {
      $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
 
      return apply_filters( 'mdjm_event_playlist_limit', $playlist_limit, $event_id );
-} // mdjm_get_playlist_limit
+} // mdjm_get_event_playlist_limit
 
 /**
  * Determine if this event has playlists enabled.

--- a/includes/playlist/playlist-functions.php
+++ b/includes/playlist/playlist-functions.php
@@ -344,14 +344,14 @@ function mdjm_get_event_playlist_categories( $event_id, $args=array() )	{
 	return $categories;
 } // mdjm_get_event_playlist_categories
 
-/** Get the playlist  limit count
+/** Get the playlist limit for this event
  *
  */
 
 function mdjm_get_playlist_limit ( $event_id )  {
      $playlist_limit = get_post_meta( $event_id, '_mdjm_event_playlist_limit', true );
      return $playlist_limit;
-}
+} // mdjm_get_playlist_limit
 
 /**
  * Determine if this event has playlists enabled.

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -44,7 +44,7 @@ global $mdjm_event;
 
         
        	<?php if( $mdjm_event->playlist_is_open() ) : ?>
-            <?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+            <?php $event_playlist_limit = mdjm_get_event_playlist_limit( $mdjm_event->ID ); ?>
             <?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
     		<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
                 <form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -44,65 +44,74 @@ global $mdjm_event;
 
         
        	<?php if( $mdjm_event->playlist_is_open() ) : ?>
-		<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-		<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
-		<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
-            		<form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
-                		<?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
-                		<?php mdjm_action_field( 'add_playlist_entry' ); ?>
-                		<input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
-               		 	<table id="mdjm-playlist-form-table">
-                    	 	<tr>
-                        		<td class="mdjm-playlist-song-cell">
-                            			<label for="entry_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
-                            			<input type="text" name="entry_song" id="entry_song" data-placeholder="<?php _e( 'Song Name', 'mobile-dj-manager' ); ?>" required />
-                        		</td>
+            <?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+            <?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+    		<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
+                <form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
+                    <?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
+                    <?php mdjm_action_field( 'add_playlist_entry' ); ?>
+                    <input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
+                    <table id="mdjm-playlist-form-table">
+                        <tr>
+                            <td class="mdjm-playlist-song-cell">
+                                    <label for="entry_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
+                                    <input type="text" name="entry_song" id="entry_song" data-placeholder="<?php _e( 'Song Name', 'mobile-dj-manager' ); ?>" required />
+                            </td>
 
-                        		<td class="mdjm-playlist-artist-cell">
-						<label for="entry_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
-	                            		<input type="text" name="entry_artist" id="entry_artist" data-placeholder="<?php _e( 'Artist Name', 'mobile-dj-manager' ); ?>" required />
-                        		</td>
+                            <td class="mdjm-playlist-artist-cell">
+                                <label for="entry_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
+                                <input type="text" name="entry_artist" id="entry_artist" data-placeholder="<?php _e( 'Artist Name', 'mobile-dj-manager' ); ?>" required />
+                            </td>
 
-	                        	<td class="mdjm-playlist-category-cell">
-        	                    		<label for="entry_category"><?php _e( 'Category', 'mobile-dj-manager' ); ?></label><br />
-                	            		<?php mdjm_playlist_category_dropdown(); ?>
-                        		</td>
+                            <td class="mdjm-playlist-category-cell">
+                                    <label for="entry_category"><?php _e( 'Category', 'mobile-dj-manager' ); ?></label><br />
+                                    <?php mdjm_playlist_category_dropdown(); ?>
+                            </td>
 
-                       			<td class="mdjm-playlist-djnotes-cell">
-                            			<label for="mdjm_playlist_djnotes"><?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?></label><br />
-				        	<textarea name="entry_djnotes" id="entry_djnotes" data-placeholder="<?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?>"></textarea>
-	                        	</td>
+                            <td class="mdjm-playlist-djnotes-cell">
+                                <label for="mdjm_playlist_djnotes"><?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?></label><br />
+                                <textarea name="entry_djnotes" id="entry_djnotes" data-placeholder="<?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?>"></textarea>
+                            </td>
         	        	</tr>
                 		<tr>
-                    			<td class="mdjm-playlist-addnew-cell" colspan="4">
-                            			<input type="submit" name="entry_addnew" id="entry_addnew" value="<?php _e( 'Add to Playlist', 'mobile-dj-manager' ); ?>" />
-                        		</td>
-                    		</tr>
-                		</table>
-	            	</form>
-		<?php else : ?>
-			<p><?php printf( __( 'You have used %d %s our of your allowance of %d in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), 
-					$entries_in_playlist,
-                                        _n( 'track', 'tracks', $entries_in_playlist, 'mobile-dj-manager' ),
-					$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
-		<?php endif; // endif  ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
-	<?php else : ?>
-        		<style type="text/css">
-				.mdjm-playlist-remove	{
-					display: none;
-				}
-			</style>
-        		<?php do_action( 'mdjm_playlist_closed', $mdjm_event->ID ); ?>
+                            <td class="mdjm-playlist-addnew-cell" colspan="4">
+                                <input type="submit" name="entry_addnew" id="entry_addnew" value="<?php _e( 'Add to Playlist', 'mobile-dj-manager' ); ?>" />
+                            </td>
+                        </tr>
+                    </table>
+                </form>
+            <?php else : ?>
+                <p><?php printf(
+                    __( 'You have used %d %s our of your allowance of %d in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), 
+                    $entries_in_playlist,
+                    _n( 'track', 'tracks', $entries_in_playlist, 'mobile-dj-manager' ),
+                    $event_playlist_limit, mdjm_get_label_singular( true )
+                ); ?></p>
+            <?php endif; // endif  ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
 
-            		<p><?php printf( __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ), '{dj_firstname}' ); ?></p>
+        <?php else : ?>
+            <style type="text/css">
+                .mdjm-playlist-remove	{
+                    display: none;
+                }
+			</style>
+            <?php do_action( 'mdjm_playlist_closed', $mdjm_event->ID ); ?>
+
+            <p><?php printf(
+                __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ),#
+                mdjm_get_label_singular( true ),
+                '{dj_firstname}'
+            ); ?></p>
 
        	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+
     	<?php do_action( 'mdjm_playlist_form_bottom', $mdjm_event->ID ); ?>
+
 	</div><!-- end mdjm-playlist-form -->
     	
 	<?php $playlist = mdjm_get_playlist_by_category( $mdjm_event->ID ); ?>
     
-    <?php if( $playlist ) : ?>
+    <?php if ( $playlist ) : ?>
     	 <div id="mdjm-playlist-entries">
         	<?php do_action( 'mdjm_playlist_entries_top', $mdjm_event->ID ); ?>
         	<p><?php printf( __( 'Your playlist currently consists of %d %s and is approximately %s long. Your %s is %s long.', 'mobile-dj-manager' ),
@@ -116,56 +125,58 @@ global $mdjm_event;
 			<p><?php printf( __( 'You have used %s out of your allowance of %s tracks'), $entries_in_playlist, $event_playlist_limit ); ?></p>
 		<?php endif; ?>        
 
-        	<?php foreach( $playlist as $category => $entries ) : ?>
-            	
-				<?php $entries_in_category = mdjm_count_playlist_entries( $mdjm_event->ID, $category ); ?>
-                
-                <div class="row">
-                
-                    <div class="category"><?php echo $category; ?> <span class="cat-count">(<?php echo $entries_in_category; ?> <?php echo _n( 'entry', 'entries', $entries_in_category, 'mobile-dj-manager' ); ?> | <?php echo mdjm_playlist_duration( $mdjm_event->ID, $entries_in_category ); ?>)</span></div>
-                    
+        <?php foreach( $playlist as $category => $entries ) : ?>
+
+            <?php $entries_in_category = mdjm_count_playlist_entries( $mdjm_event->ID, $category ); ?>
+
+            <div class="row">
+
+                <div class="category">
+                    <?php echo $category; ?> <span class="cat-count">(<?php echo $entries_in_category; ?> <?php echo _n( 'entry', 'entries', $entries_in_category, 'mobile-dj-manager' ); ?> | <?php echo mdjm_playlist_duration( $mdjm_event->ID, $entries_in_category ); ?>)</span>
                 </div>
+
+            </div>
                 
-                <?php foreach( $entries as $entry ) : ?>
-                	
-                    <?php $entry_data = mdjm_get_playlist_entry_data( $entry->ID ); ?>
-                    
-                	<div class="row mdjm-playlist-entry mdjm-playlist-entry-<?php echo $entry->id; ?>">
-                    	<div class="mdjm-playlist-song col"><?php echo $entry_data['song']; ?></div>
-                        
-                        <div class="mdjm-playlist-artist col"><?php echo $entry_data['artist']; ?></div>
-                        
-                        <div class="mdjm-playlist-info col">
-							<?php if( $category == 'Guest' ) : ?>
-                            
-                            	<?php echo stripslashes( $entry_data['added_by'] ); ?>
-                            
-							<?php elseif( ! empty( $entry_data['djnotes'] ) ) : ?>
-									
-								<?php echo stripslashes( $entry_data['djnotes'] ); ?>
-                                
-							<?php else : ?>
-                                	
-								<?php echo '&ndash;'; ?>
-								
-							<?php endif; // endif( $category == 'Guest Added' ) ?>
-                        </div>
-                        
-                        <div class="mdjm-playlist-remove last"><a href="<?php echo wp_nonce_url( mdjm_get_formatted_url( mdjm_get_option( 'playlist_page' ) ) . 'mdjm_action=remove_playlist_entry&id=' . $entry->ID . '&event_id=' . $mdjm_event->ID, 'remove_playlist_entry', 'mdjm_nonce' ); ?>"><?php _e( 'Remove', 'mobile-dj-manager' ); ?></a>
+            <?php foreach( $entries as $entry ) : ?>
+
+                <?php $entry_data = mdjm_get_playlist_entry_data( $entry->ID ); ?>
+
+                <div class="row mdjm-playlist-entry mdjm-playlist-entry-<?php echo $entry->id; ?>">
+                    <div class="mdjm-playlist-song col"><?php echo $entry_data['song']; ?></div>
+
+                    <div class="mdjm-playlist-artist col"><?php echo $entry_data['artist']; ?></div>
+
+                    <div class="mdjm-playlist-info col">
+                        <?php if( $category == 'Guest' ) : ?>
+
+                            <?php echo stripslashes( $entry_data['added_by'] ); ?>
+
+                        <?php elseif( ! empty( $entry_data['djnotes'] ) ) : ?>
+
+                            <?php echo stripslashes( $entry_data['djnotes'] ); ?>
+
+                        <?php else : ?>
+
+                            <?php echo '&ndash;'; ?>
+
+                        <?php endif; // endif( $category == 'Guest Added' ) ?>
+                    </div>
+
+                    <div class="mdjm-playlist-remove last">
+                        <a href="<?php echo wp_nonce_url( mdjm_get_formatted_url( mdjm_get_option( 'playlist_page' ) ) . 'mdjm_action=remove_playlist_entry&id=' . $entry->ID . '&event_id=' . $mdjm_event->ID, 'remove_playlist_entry', 'mdjm_nonce' ); ?>"><?php _e( 'Remove', 'mobile-dj-manager' ); ?></a>
                     </div>
                 </div>
-                
-                <?php endforeach; // end foreach( $entries as $entry ) ?>
-                
-            <?php endforeach; // end foreach( $playlist as $entry ) ?>
-        
+
+            <?php endforeach; // end foreach( $entries as $entry ) ?>
+
+        <?php endforeach; // end foreach( $playlist as $entry ) ?>
+
         </div><!-- end mdjm-playlist-entries -->
 	
 	<?php endif; // endif( $playlist ) ?>
     	
 	<?php do_action( 'mdjm_playlist_entries_bottom', $mdjm_event->ID ); ?>
     
-    	
     <div id="mdjm-playlist-footer">
     	<?php do_action( 'mdjm_playlist_footer_top', $mdjm_event->ID ); ?>
     	<?php do_action( 'mdjm_playlist_footer_bottom', $mdjm_event->ID ); ?>

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -42,60 +42,60 @@ global $mdjm_event;
 	<div id="mdjm-playlist-form">
     	<?php do_action( 'mdjm_playlist_form_top', $mdjm_event->ID ); ?>
 
-<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+	<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+	<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
         
-<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
-        <?php if( $mdjm_event->playlist_is_open() ) : ?>
-            <form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
-                <?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
-                <?php mdjm_action_field( 'add_playlist_entry' ); ?>
-                <input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
+	<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
+        	<?php if( $mdjm_event->playlist_is_open() ) : ?>
+            	<form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
+                	<?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
+                	<?php mdjm_action_field( 'add_playlist_entry' ); ?>
+                	<input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
                 
-                <table id="mdjm-playlist-form-table">
-                    <tr>
-                        <td class="mdjm-playlist-song-cell">
-                            <label for="entry_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
-                            <input type="text" name="entry_song" id="entry_song" data-placeholder="<?php _e( 'Song Name', 'mobile-dj-manager' ); ?>" required />
-                        </td>
+               		 <table id="mdjm-playlist-form-table">
+                    	 <tr>
+                        	<td class="mdjm-playlist-song-cell">
+                            		<label for="entry_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
+                            		<input type="text" name="entry_song" id="entry_song" data-placeholder="<?php _e( 'Song Name', 'mobile-dj-manager' ); ?>" required />
+                        	</td>
                         
-                        <td class="mdjm-playlist-artist-cell">
-                            <label for="entry_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
-                            <input type="text" name="entry_artist" id="entry_artist" data-placeholder="<?php _e( 'Artist Name', 'mobile-dj-manager' ); ?>" required />
-                        </td>
+                        	<td class="mdjm-playlist-artist-cell">
+					<label for="entry_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
+	                            	<input type="text" name="entry_artist" id="entry_artist" data-placeholder="<?php _e( 'Artist Name', 'mobile-dj-manager' ); ?>" required />
+                        	</td>
                         
-                        <td class="mdjm-playlist-category-cell">
-                            <label for="entry_category"><?php _e( 'Category', 'mobile-dj-manager' ); ?></label><br />
-                            <?php mdjm_playlist_category_dropdown(); ?>
-                        </td>
+	                        <td class="mdjm-playlist-category-cell">
+        	                    <label for="entry_category"><?php _e( 'Category', 'mobile-dj-manager' ); ?></label><br />
+                	            <?php mdjm_playlist_category_dropdown(); ?>
+                        	</td>
                         
-                        <td class="mdjm-playlist-djnotes-cell">
-                            <label for="mdjm_playlist_djnotes"><?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?></label><br />
-                            <textarea name="entry_djnotes" id="entry_djnotes" data-placeholder="<?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?>"></textarea>
-                        </td>
-                    </tr>
-                    <tr>
-                    	<td class="mdjm-playlist-addnew-cell" colspan="4">
-                            <input type="submit" name="entry_addnew" id="entry_addnew" value="<?php _e( 'Add to Playlist', 'mobile-dj-manager' ); ?>" />
-                        </td>
-                    </tr>
-                </table>
+                       		<td class="mdjm-playlist-djnotes-cell">
+                            		<label for="mdjm_playlist_djnotes"><?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?></label><br />
+				        <textarea name="entry_djnotes" id="entry_djnotes" data-placeholder="<?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?>"></textarea>
+	                        </td>
+        	        </tr>
+                	<tr>
+                    		<td class="mdjm-playlist-addnew-cell" colspan="4">
+                            	<input type="submit" name="entry_addnew" id="entry_addnew" value="<?php _e( 'Add to Playlist', 'mobile-dj-manager' ); ?>" />
+                        	</td>
+                    	</tr>
+                	</table>
             </form>
             
-        <?php else : ?>
-        <style type="text/css">
-		.mdjm-playlist-remove	{
-			display: none;
-		}
-		</style>
-        	<?php do_action( 'mdjm_playlist_closed', $mdjm_event->ID ); ?>
+	        <?php else : ?>
+        		<style type="text/css">
+				.mdjm-playlist-remove	{
+					display: none;
+				}
+			</style>
+        		<?php do_action( 'mdjm_playlist_closed', $mdjm_event->ID ); ?>
             
-            <p><?php printf( __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ), '{dj_firstname}' ); ?></p>
+            		<p><?php printf( __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ), '{dj_firstname}' ); ?></p>
             
-        <?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
-<?php else : ?>
-<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
-<?php endif; // endif test if playlist limit reached ?>
+        	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+	<?php else : ?>
+		<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
+	<?php endif; // endif test if playlist limit reached ?>
     	<?php do_action( 'mdjm_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-form -->
     	
@@ -111,9 +111,9 @@ global $mdjm_event;
 					mdjm_get_label_singular(),
 					'{event_duration}' ); ?></p>
 
-<?php if ( $event_playlist_limit ) : ?>
-<p><?php printf( __( 'You have used %s out of your allowance of %s tracks'), $entries_in_playlist, $event_playlist_limit ); ?></p>
-<?php endif; ?>        
+		<?php if ( $event_playlist_limit ) : ?>
+			<p><?php printf( __( 'You have used %s out of your allowance of %s tracks'), $entries_in_playlist, $event_playlist_limit ); ?></p>
+		<?php endif; ?>        
 
         	<?php foreach( $playlist as $category => $entries ) : ?>
             	

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -41,9 +41,12 @@ global $mdjm_event;
     
 	<div id="mdjm-playlist-form">
     	<?php do_action( 'mdjm_playlist_form_top', $mdjm_event->ID ); ?>
+
+<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
         
+<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
         <?php if( $mdjm_event->playlist_is_open() ) : ?>
-        
             <form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
                 <?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
                 <?php mdjm_action_field( 'add_playlist_entry' ); ?>
@@ -90,7 +93,9 @@ global $mdjm_event;
             <p><?php printf( __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ), '{dj_firstname}' ); ?></p>
             
         <?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
-        
+<?php else : ?>
+<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
+<?php endif; // endif test if playlist limit reached ?>
     	<?php do_action( 'mdjm_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-form -->
     	
@@ -99,15 +104,17 @@ global $mdjm_event;
     <?php if( $playlist ) : ?>
     	 <div id="mdjm-playlist-entries">
         	<?php do_action( 'mdjm_playlist_entries_top', $mdjm_event->ID ); ?>
-            
-        	<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
         	<p><?php printf( __( 'Your playlist currently consists of %d %s and is approximately %s long. Your %s is %s long.', 'mobile-dj-manager' ),
 					$entries_in_playlist,
 					_n( 'track', 'tracks', $entries_in_playlist, 'mobile-dj-manager' ),
 					'{playlist_duration}',
 					mdjm_get_label_singular(),
 					'{event_duration}' ); ?></p>
-        
+
+<?php if ( $event_playlist_limit ) : ?>
+<p><?php printf( __( 'You have used %s out of your allowance of %s tracks'), $entries_in_playlist, $event_playlist_limit ); ?></p>
+<?php endif; ?>        
+
         	<?php foreach( $playlist as $category => $entries ) : ?>
             	
 				<?php $entries_in_category = mdjm_count_playlist_entries( $mdjm_event->ID, $category ); ?>

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -79,23 +79,21 @@ global $mdjm_event;
                         		</td>
                     		</tr>
                 		</table>
-            	</form>
+	            	</form>
 		<?php else : ?>
 			<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
 		<?php endif; // endif  ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
-            
-	        <?php else : ?>
+	<?php else : ?>
         		<style type="text/css">
 				.mdjm-playlist-remove	{
 					display: none;
 				}
 			</style>
         		<?php do_action( 'mdjm_playlist_closed', $mdjm_event->ID ); ?>
-            
+
             		<p><?php printf( __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ), '{dj_firstname}' ); ?></p>
 
-            
-        	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+       	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
     	<?php do_action( 'mdjm_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-form -->
     	

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -81,7 +81,10 @@ global $mdjm_event;
                 		</table>
 	            	</form>
 		<?php else : ?>
-			<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
+			<p><?php printf( __( 'You have used %d %s our of your allowance of %d in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), 
+					$entries_in_playlist,
+                                        _n( 'track', 'tracks', $entries_in_playlist, 'mobile-dj-manager' ),
+					$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
 		<?php endif; // endif  ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
 	<?php else : ?>
         		<style type="text/css">

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -42,45 +42,47 @@ global $mdjm_event;
 	<div id="mdjm-playlist-form">
     	<?php do_action( 'mdjm_playlist_form_top', $mdjm_event->ID ); ?>
 
-	<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-	<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
         
-	<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
-        	<?php if( $mdjm_event->playlist_is_open() ) : ?>
-            	<form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
-                	<?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
-                	<?php mdjm_action_field( 'add_playlist_entry' ); ?>
-                	<input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
-                
-               		 <table id="mdjm-playlist-form-table">
-                    	 <tr>
-                        	<td class="mdjm-playlist-song-cell">
-                            		<label for="entry_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
-                            		<input type="text" name="entry_song" id="entry_song" data-placeholder="<?php _e( 'Song Name', 'mobile-dj-manager' ); ?>" required />
-                        	</td>
-                        
-                        	<td class="mdjm-playlist-artist-cell">
-					<label for="entry_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
-	                            	<input type="text" name="entry_artist" id="entry_artist" data-placeholder="<?php _e( 'Artist Name', 'mobile-dj-manager' ); ?>" required />
-                        	</td>
-                        
-	                        <td class="mdjm-playlist-category-cell">
-        	                    <label for="entry_category"><?php _e( 'Category', 'mobile-dj-manager' ); ?></label><br />
-                	            <?php mdjm_playlist_category_dropdown(); ?>
-                        	</td>
-                        
-                       		<td class="mdjm-playlist-djnotes-cell">
-                            		<label for="mdjm_playlist_djnotes"><?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?></label><br />
-				        <textarea name="entry_djnotes" id="entry_djnotes" data-placeholder="<?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?>"></textarea>
-	                        </td>
-        	        </tr>
-                	<tr>
-                    		<td class="mdjm-playlist-addnew-cell" colspan="4">
-                            	<input type="submit" name="entry_addnew" id="entry_addnew" value="<?php _e( 'Add to Playlist', 'mobile-dj-manager' ); ?>" />
-                        	</td>
-                    	</tr>
-                	</table>
-            </form>
+       	<?php if( $mdjm_event->playlist_is_open() ) : ?>
+		<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+		<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+		<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
+            		<form id="mdjm-playlist-form" name="mdjm-playlist-form" action="" method="post">
+                		<?php wp_nonce_field( 'add_playlist_entry', 'mdjm_nonce', true, true ); ?>
+                		<?php mdjm_action_field( 'add_playlist_entry' ); ?>
+                		<input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
+               		 	<table id="mdjm-playlist-form-table">
+                    	 	<tr>
+                        		<td class="mdjm-playlist-song-cell">
+                            			<label for="entry_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
+                            			<input type="text" name="entry_song" id="entry_song" data-placeholder="<?php _e( 'Song Name', 'mobile-dj-manager' ); ?>" required />
+                        		</td>
+
+                        		<td class="mdjm-playlist-artist-cell">
+						<label for="entry_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
+	                            		<input type="text" name="entry_artist" id="entry_artist" data-placeholder="<?php _e( 'Artist Name', 'mobile-dj-manager' ); ?>" required />
+                        		</td>
+
+	                        	<td class="mdjm-playlist-category-cell">
+        	                    		<label for="entry_category"><?php _e( 'Category', 'mobile-dj-manager' ); ?></label><br />
+                	            		<?php mdjm_playlist_category_dropdown(); ?>
+                        		</td>
+
+                       			<td class="mdjm-playlist-djnotes-cell">
+                            			<label for="mdjm_playlist_djnotes"><?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?></label><br />
+				        	<textarea name="entry_djnotes" id="entry_djnotes" data-placeholder="<?php printf( __( 'Notes for your %s', 'mobile-dj-manager' ), '{artist_label}' ); ?>"></textarea>
+	                        	</td>
+        	        	</tr>
+                		<tr>
+                    			<td class="mdjm-playlist-addnew-cell" colspan="4">
+                            			<input type="submit" name="entry_addnew" id="entry_addnew" value="<?php _e( 'Add to Playlist', 'mobile-dj-manager' ); ?>" />
+                        		</td>
+                    		</tr>
+                		</table>
+            	</form>
+		<?php else : ?>
+			<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
+		<?php endif; // endif  ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
             
 	        <?php else : ?>
         		<style type="text/css">
@@ -91,11 +93,9 @@ global $mdjm_event;
         		<?php do_action( 'mdjm_playlist_closed', $mdjm_event->ID ); ?>
             
             		<p><?php printf( __( 'The playlist for this %s is currently closed to allow %s to prepare for your event. Existing playlist entries are displayed below.', 'mobile-dj-manager' ), mdjm_get_label_singular( true ), '{dj_firstname}' ); ?></p>
+
             
         	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
-	<?php else : ?>
-		<p><?php printf( __( 'You have used %s tracks our of your allowance of %s in the playlist for your %s.  Existing playlist entries are displayed below.', 'mobile-dj-manager' ), $entries_in_playlist,$event_playlist_limit, mdjm_get_label_singular( true ) ); ?></p>
-	<?php endif; // endif test if playlist limit reached ?>
     	<?php do_action( 'mdjm_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-form -->
     	

--- a/templates/playlist/playlist-client.php
+++ b/templates/playlist/playlist-client.php
@@ -43,7 +43,7 @@ global $mdjm_event;
     	<?php do_action( 'mdjm_playlist_form_top', $mdjm_event->ID ); ?>
 
 	<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-	<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+	<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
         
 	<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?>
         	<?php if( $mdjm_event->playlist_is_open() ) : ?>

--- a/templates/playlist/playlist-guest.php
+++ b/templates/playlist/playlist-guest.php
@@ -39,7 +39,9 @@ global $mdjm_event;
     
     	<?php do_action( 'mdjm_guest_playlist_header_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-header -->
-    
+<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
 	<div id="mdjm-guest-playlist-form">
     	<?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
         
@@ -87,6 +89,11 @@ global $mdjm_event;
 						"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
             
         <?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+<?php else : ?>
+            <p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is currently full.', 'mobile-dj-manager' ),
+						"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
+
+<?php endif; //endif($entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
         
     	<?php do_action( 'mdjm_guest_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-guest-playlist-form -->

--- a/templates/playlist/playlist-guest.php
+++ b/templates/playlist/playlist-guest.php
@@ -39,63 +39,74 @@ global $mdjm_event;
     
     	<?php do_action( 'mdjm_guest_playlist_header_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-header -->
-		<div id="mdjm-guest-playlist-form">
-    		<?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
-        <?php if( $mdjm_event->playlist_is_open() ) : ?>
-		<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-		<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
-		<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
+    <div id="mdjm-guest-playlist-form">
+
+        <?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
+
+        <?php if ( $mdjm_event->playlist_is_open() ) : ?>
+            <?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+            <?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+
+            <?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) : ?> 
 
         	   	<form id="mdjm-guest-playlist-form" name="mdjm-guest-playlist-form" action="" method="post">
-                		<?php wp_nonce_field( 'add_guest_playlist_entry', 'mdjm_nonce', true, true ); ?>
-	                	<?php mdjm_action_field( 'add_guest_playlist_entry' ); ?>
-        	        	<input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
+                    <?php wp_nonce_field( 'add_guest_playlist_entry', 'mdjm_nonce', true, true ); ?>
+                    <?php mdjm_action_field( 'add_guest_playlist_entry' ); ?>
+                    <input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
 
-	                	<table id="mdjm-guest-playlist-form-table">
-        	            	<tr>
-                	        	<td class="mdjm-guest-playlist-firstname-cell">
-                        	    		<label for="entry_guest_firstname"><?php _e( 'First Name', 'mobile-dj-manager' ); ?></label><br />
-                            			<input type="text" name="entry_guest_firstname" id="entry_guest_firstname" data-placeholder="<?php _e( 'First Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['firstname'] ) ) : echo $mdjm_guest['firstname']; endif; ?>" required />
-                        		</td>
+                    <table id="mdjm-guest-playlist-form-table">
+                        <tr>
+                            <td class="mdjm-guest-playlist-firstname-cell">
+                                    <label for="entry_guest_firstname"><?php _e( 'First Name', 'mobile-dj-manager' ); ?></label><br />
+                                    <input type="text" name="entry_guest_firstname" id="entry_guest_firstname" data-placeholder="<?php _e( 'First Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['firstname'] ) ) : echo $mdjm_guest['firstname']; endif; ?>" required />
+                            </td>
 
-                        		<td class="mdjm-guest-playlist-lastname-cell">
-                            			<label for="entry_guest_lastname"><?php _e( 'Last Name', 'mobile-dj-manager' ); ?></label><br />
-                            			<input type="text" name="entry_guest_lastname" id="entry_guest_lastname" data-placeholder="<?php _e( 'Last Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['lastname'] ) ) : echo $mdjm_guest['lastname']; endif; ?>" required />
-                        		</td>
+                            <td class="mdjm-guest-playlist-lastname-cell">
+                                    <label for="entry_guest_lastname"><?php _e( 'Last Name', 'mobile-dj-manager' ); ?></label><br />
+                                    <input type="text" name="entry_guest_lastname" id="entry_guest_lastname" data-placeholder="<?php _e( 'Last Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['lastname'] ) ) : echo $mdjm_guest['lastname']; endif; ?>" required />
+                            </td>
 
-                        		<td class="mdjm-guest-playlist-category-cell">
-                            			<label for="entry_guest_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
-                            			<input type="text" name="entry_guest_song" id="entry_guest_song" data-placeholder="<?php _e( 'Song', 'mobile-dj-manager' ); ?>" />
-                        		</td>
+                            <td class="mdjm-guest-playlist-category-cell">
+                                    <label for="entry_guest_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
+                                    <input type="text" name="entry_guest_song" id="entry_guest_song" data-placeholder="<?php _e( 'Song', 'mobile-dj-manager' ); ?>" />
+                            </td>
 
-                        		<td class="mdjm-guest-playlist-djnotes-cell">
-                            			<label for="entry_guest_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
-                            			<input type="text" name="entry_guest_artist" id="entry_guest_artist" data-placeholder="<?php _e( 'Artist', 'mobile-dj-manager' ); ?>" />
-                        		</td>
-                    		</tr>
-                    		<tr>
-                    			<td class="mdjm-guest-playlist-addnew-cell" colspan="4">
-                            			<input type="submit" name="entry_guest_addnew" id="entry_guest_addnew" value="<?php _e( 'Suggest Song', 'mobile-dj-manager' ); ?>" />
-                        		</td>
-                    		</tr>
-                		</table>
-            		</form>
+                            <td class="mdjm-guest-playlist-djnotes-cell">
+                                    <label for="entry_guest_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
+                                    <input type="text" name="entry_guest_artist" id="entry_guest_artist" data-placeholder="<?php _e( 'Artist', 'mobile-dj-manager' ); ?>" />
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="mdjm-guest-playlist-addnew-cell" colspan="4">
+                                    <input type="submit" name="entry_guest_addnew" id="entry_guest_addnew" value="<?php _e( 'Suggest Song', 'mobile-dj-manager' ); ?>" />
+                            </td>
+                        </tr>
+                    </table>
+                </form>
 
-		<?php else : ?>
-        	    <p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is currently full.', 'mobile-dj-manager' ),
-					"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
-		<?php endif; //endif($entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
+            <?php else : ?>
+        	    <p><?php printf(
+                    __( 'Sorry but the music playlist system for %s %s on %s is currently full.', 'mobile-dj-manager' ),
+					"{client_fullname}'s",
+                    '{event_type}',
+                    '{event_date}'
+                ); ?></p>
+            <?php endif; //endif ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
 
        	<?php else : ?>
        		<?php do_action( 'mdjm_guest_playlist_closed', $mdjm_event->ID ); ?>
-       		<p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is no longer accepting suggestions.', 'mobile-dj-manager' ),
-				"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
+
+       		<p><?php printf(
+                __( 'Sorry but the music playlist system for %s %s on %s is no longer accepting suggestions.', 'mobile-dj-manager' ),
+				"{client_fullname}'s",
+                '{event_type}',
+                '{event_date}' );
+            ?></p>
+
        	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
 
     	<?php do_action( 'mdjm_guest_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-guest-playlist-form -->
-    	
-    
     	
     <div id="mdjm-guest-playlist-footer">
     	<?php do_action( 'mdjm_guest_playlist_footer_top', $mdjm_event->ID ); ?>

--- a/templates/playlist/playlist-guest.php
+++ b/templates/playlist/playlist-guest.php
@@ -39,63 +39,59 @@ global $mdjm_event;
     
     	<?php do_action( 'mdjm_guest_playlist_header_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-header -->
-	<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-	<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
-	<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
 		<div id="mdjm-guest-playlist-form">
     		<?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
-        
-	        <?php if( $mdjm_event->playlist_is_open() ) : ?>
-        
+        <?php if( $mdjm_event->playlist_is_open() ) : ?>
+		<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+		<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+		<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
+
         	   	<form id="mdjm-guest-playlist-form" name="mdjm-guest-playlist-form" action="" method="post">
-                	<?php wp_nonce_field( 'add_guest_playlist_entry', 'mdjm_nonce', true, true ); ?>
-	                <?php mdjm_action_field( 'add_guest_playlist_entry' ); ?>
-        	        <input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
-                
-                	<table id="mdjm-guest-playlist-form-table">
-                    	<tr>
-                        	<td class="mdjm-guest-playlist-firstname-cell">
-                            		<label for="entry_guest_firstname"><?php _e( 'First Name', 'mobile-dj-manager' ); ?></label><br />
-                            		<input type="text" name="entry_guest_firstname" id="entry_guest_firstname" data-placeholder="<?php _e( 'First Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['firstname'] ) ) : echo $mdjm_guest['firstname']; endif; ?>" required />
-                        	</td>
-                        
-                        	<td class="mdjm-guest-playlist-lastname-cell">
-                            		<label for="entry_guest_lastname"><?php _e( 'Last Name', 'mobile-dj-manager' ); ?></label><br />
-                            		<input type="text" name="entry_guest_lastname" id="entry_guest_lastname" data-placeholder="<?php _e( 'Last Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['lastname'] ) ) : echo $mdjm_guest['lastname']; endif; ?>" required />
-                        	</td>
-                        
-                        	<td class="mdjm-guest-playlist-category-cell">
-                            		<label for="entry_guest_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
-                            		<input type="text" name="entry_guest_song" id="entry_guest_song" data-placeholder="<?php _e( 'Song', 'mobile-dj-manager' ); ?>" />
-                        	</td>
-                        
-                        	<td class="mdjm-guest-playlist-djnotes-cell">
-                            		<label for="entry_guest_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
-                            		<input type="text" name="entry_guest_artist" id="entry_guest_artist" data-placeholder="<?php _e( 'Artist', 'mobile-dj-manager' ); ?>" />
-                        	</td>
-                    	</tr>
-                    	<tr>
-                    		<td class="mdjm-guest-playlist-addnew-cell" colspan="4">
-                            		<input type="submit" name="entry_guest_addnew" id="entry_guest_addnew" value="<?php _e( 'Suggest Song', 'mobile-dj-manager' ); ?>" />
-                        	</td>
-                    	</tr>
-                	</table>
-            	</form>
-            
-        	<?php else : ?>
-        		<?php do_action( 'mdjm_guest_playlist_closed', $mdjm_event->ID ); ?>
-            
-            		<p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is no longer accepting suggestions.', 'mobile-dj-manager' ),
-						"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
-            
-        	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+                		<?php wp_nonce_field( 'add_guest_playlist_entry', 'mdjm_nonce', true, true ); ?>
+	                	<?php mdjm_action_field( 'add_guest_playlist_entry' ); ?>
+        	        	<input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
 
-	<?php else : ?>
-            <p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is currently full.', 'mobile-dj-manager' ),
-						"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
+	                	<table id="mdjm-guest-playlist-form-table">
+        	            	<tr>
+                	        	<td class="mdjm-guest-playlist-firstname-cell">
+                        	    		<label for="entry_guest_firstname"><?php _e( 'First Name', 'mobile-dj-manager' ); ?></label><br />
+                            			<input type="text" name="entry_guest_firstname" id="entry_guest_firstname" data-placeholder="<?php _e( 'First Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['firstname'] ) ) : echo $mdjm_guest['firstname']; endif; ?>" required />
+                        		</td>
 
-	<?php endif; //endif($entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
-        
+                        		<td class="mdjm-guest-playlist-lastname-cell">
+                            			<label for="entry_guest_lastname"><?php _e( 'Last Name', 'mobile-dj-manager' ); ?></label><br />
+                            			<input type="text" name="entry_guest_lastname" id="entry_guest_lastname" data-placeholder="<?php _e( 'Last Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['lastname'] ) ) : echo $mdjm_guest['lastname']; endif; ?>" required />
+                        		</td>
+
+                        		<td class="mdjm-guest-playlist-category-cell">
+                            			<label for="entry_guest_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
+                            			<input type="text" name="entry_guest_song" id="entry_guest_song" data-placeholder="<?php _e( 'Song', 'mobile-dj-manager' ); ?>" />
+                        		</td>
+
+                        		<td class="mdjm-guest-playlist-djnotes-cell">
+                            			<label for="entry_guest_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
+                            			<input type="text" name="entry_guest_artist" id="entry_guest_artist" data-placeholder="<?php _e( 'Artist', 'mobile-dj-manager' ); ?>" />
+                        		</td>
+                    		</tr>
+                    		<tr>
+                    			<td class="mdjm-guest-playlist-addnew-cell" colspan="4">
+                            			<input type="submit" name="entry_guest_addnew" id="entry_guest_addnew" value="<?php _e( 'Suggest Song', 'mobile-dj-manager' ); ?>" />
+                        		</td>
+                    		</tr>
+                		</table>
+            		</form>
+
+		<?php else : ?>
+        	    <p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is currently full.', 'mobile-dj-manager' ),
+					"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
+		<?php endif; //endif($entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
+
+       	<?php else : ?>
+       		<?php do_action( 'mdjm_guest_playlist_closed', $mdjm_event->ID ); ?>
+       		<p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is no longer accepting suggestions.', 'mobile-dj-manager' ),
+				"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
+       	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+
     	<?php do_action( 'mdjm_guest_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-guest-playlist-form -->
     	

--- a/templates/playlist/playlist-guest.php
+++ b/templates/playlist/playlist-guest.php
@@ -40,7 +40,7 @@ global $mdjm_event;
     	<?php do_action( 'mdjm_guest_playlist_header_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-header -->
 	<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-	<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+	<?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
 	<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
 		<div id="mdjm-guest-playlist-form">
     		<?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>

--- a/templates/playlist/playlist-guest.php
+++ b/templates/playlist/playlist-guest.php
@@ -39,61 +39,62 @@ global $mdjm_event;
     
     	<?php do_action( 'mdjm_guest_playlist_header_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-playlist-header -->
-<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
-<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
-<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
-	<div id="mdjm-guest-playlist-form">
-    	<?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
+	<?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+	<?php $entries_in_playlist = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
+	<?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 )        :  ?> 
+		<div id="mdjm-guest-playlist-form">
+    		<?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
         
-        <?php if( $mdjm_event->playlist_is_open() ) : ?>
+	        <?php if( $mdjm_event->playlist_is_open() ) : ?>
         
-            <form id="mdjm-guest-playlist-form" name="mdjm-guest-playlist-form" action="" method="post">
-                <?php wp_nonce_field( 'add_guest_playlist_entry', 'mdjm_nonce', true, true ); ?>
-                <?php mdjm_action_field( 'add_guest_playlist_entry' ); ?>
-                <input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
+        	   	<form id="mdjm-guest-playlist-form" name="mdjm-guest-playlist-form" action="" method="post">
+                	<?php wp_nonce_field( 'add_guest_playlist_entry', 'mdjm_nonce', true, true ); ?>
+	                <?php mdjm_action_field( 'add_guest_playlist_entry' ); ?>
+        	        <input type="hidden" id="entry_event" name="entry_event" value="<?php echo $mdjm_event->ID; ?>" />
                 
-                <table id="mdjm-guest-playlist-form-table">
-                    <tr>
-                        <td class="mdjm-guest-playlist-firstname-cell">
-                            <label for="entry_guest_firstname"><?php _e( 'First Name', 'mobile-dj-manager' ); ?></label><br />
-                            <input type="text" name="entry_guest_firstname" id="entry_guest_firstname" data-placeholder="<?php _e( 'First Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['firstname'] ) ) : echo $mdjm_guest['firstname']; endif; ?>" required />
-                        </td>
+                	<table id="mdjm-guest-playlist-form-table">
+                    	<tr>
+                        	<td class="mdjm-guest-playlist-firstname-cell">
+                            		<label for="entry_guest_firstname"><?php _e( 'First Name', 'mobile-dj-manager' ); ?></label><br />
+                            		<input type="text" name="entry_guest_firstname" id="entry_guest_firstname" data-placeholder="<?php _e( 'First Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['firstname'] ) ) : echo $mdjm_guest['firstname']; endif; ?>" required />
+                        	</td>
                         
-                        <td class="mdjm-guest-playlist-lastname-cell">
-                            <label for="entry_guest_lastname"><?php _e( 'Last Name', 'mobile-dj-manager' ); ?></label><br />
-                            <input type="text" name="entry_guest_lastname" id="entry_guest_lastname" data-placeholder="<?php _e( 'Last Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['lastname'] ) ) : echo $mdjm_guest['lastname']; endif; ?>" required />
-                        </td>
+                        	<td class="mdjm-guest-playlist-lastname-cell">
+                            		<label for="entry_guest_lastname"><?php _e( 'Last Name', 'mobile-dj-manager' ); ?></label><br />
+                            		<input type="text" name="entry_guest_lastname" id="entry_guest_lastname" data-placeholder="<?php _e( 'Last Name', 'mobile-dj-manager' ); ?>" placeholder="<?php if( ! empty( $mdjm_guest['lastname'] ) ) : echo $mdjm_guest['lastname']; endif; ?>" required />
+                        	</td>
                         
-                        <td class="mdjm-guest-playlist-category-cell">
-                            <label for="entry_guest_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
-                            <input type="text" name="entry_guest_song" id="entry_guest_song" data-placeholder="<?php _e( 'Song', 'mobile-dj-manager' ); ?>" />
-                        </td>
+                        	<td class="mdjm-guest-playlist-category-cell">
+                            		<label for="entry_guest_song"><?php _e( 'Song', 'mobile-dj-manager' ); ?></label><br />
+                            		<input type="text" name="entry_guest_song" id="entry_guest_song" data-placeholder="<?php _e( 'Song', 'mobile-dj-manager' ); ?>" />
+                        	</td>
                         
-                        <td class="mdjm-guest-playlist-djnotes-cell">
-                            <label for="entry_guest_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
-                            <input type="text" name="entry_guest_artist" id="entry_guest_artist" data-placeholder="<?php _e( 'Artist', 'mobile-dj-manager' ); ?>" />
-                        </td>
-                    </tr>
-                    <tr>
-                    	<td class="mdjm-guest-playlist-addnew-cell" colspan="4">
-                            <input type="submit" name="entry_guest_addnew" id="entry_guest_addnew" value="<?php _e( 'Suggest Song', 'mobile-dj-manager' ); ?>" />
-                        </td>
-                    </tr>
-                </table>
-            </form>
+                        	<td class="mdjm-guest-playlist-djnotes-cell">
+                            		<label for="entry_guest_artist"><?php _e( 'Artist', 'mobile-dj-manager' ); ?></label><br />
+                            		<input type="text" name="entry_guest_artist" id="entry_guest_artist" data-placeholder="<?php _e( 'Artist', 'mobile-dj-manager' ); ?>" />
+                        	</td>
+                    	</tr>
+                    	<tr>
+                    		<td class="mdjm-guest-playlist-addnew-cell" colspan="4">
+                            		<input type="submit" name="entry_guest_addnew" id="entry_guest_addnew" value="<?php _e( 'Suggest Song', 'mobile-dj-manager' ); ?>" />
+                        	</td>
+                    	</tr>
+                	</table>
+            	</form>
             
-        <?php else : ?>
-        	<?php do_action( 'mdjm_guest_playlist_closed', $mdjm_event->ID ); ?>
+        	<?php else : ?>
+        		<?php do_action( 'mdjm_guest_playlist_closed', $mdjm_event->ID ); ?>
             
-            <p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is no longer accepting suggestions.', 'mobile-dj-manager' ),
+            		<p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is no longer accepting suggestions.', 'mobile-dj-manager' ),
 						"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
             
-        <?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
-<?php else : ?>
+        	<?php endif; // endif( mdjm_playlist_is_open( $mdjm_event->ID ) ) ?>
+
+	<?php else : ?>
             <p><?php printf( __( 'Sorry but the music playlist system for %s %s on %s is currently full.', 'mobile-dj-manager' ),
 						"{client_fullname}'s", '{event_type}', '{event_date}' ); ?></p>
 
-<?php endif; //endif($entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
+	<?php endif; //endif($entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) ?>
         
     	<?php do_action( 'mdjm_guest_playlist_form_bottom', $mdjm_event->ID ); ?>
 	</div><!-- end mdjm-guest-playlist-form -->

--- a/templates/playlist/playlist-guest.php
+++ b/templates/playlist/playlist-guest.php
@@ -44,7 +44,7 @@ global $mdjm_event;
         <?php do_action( 'mdjm_guest_playlist_form_top', $mdjm_event->ID ); ?>
 
         <?php if ( $mdjm_event->playlist_is_open() ) : ?>
-            <?php $event_playlist_limit = mdjm_get_playlist_limit( $mdjm_event->ID ); ?>
+            <?php $event_playlist_limit = mdjm_get_event_playlist_limit( $mdjm_event->ID ); ?>
             <?php $entries_in_playlist  = mdjm_count_playlist_entries( $mdjm_event->ID ); ?>
 
             <?php if ( $entries_in_playlist < $event_playlist_limit || $event_playlist_limit == 0 ) : ?> 


### PR DESCRIPTION
Here's the start of my contribution to the project - playlist limiting for events.  There's a global limit setting, which as far as I can tell is correctly assigned when a new event is created.  Each event's limit can then be changed individually.  When a client reaches their request limit, no form to add another entry is shown. Similarly when a guest accesses the unique playlist URL for the event they're told they can't currently add entries.

Please check I haven't overlooked anything w.r.t. the setting storage - everything else I've tried to follow coding standards I've seen within the project.